### PR TITLE
Edit vigenere.py

### DIFF
--- a/src/TextVault/vigenere.py
+++ b/src/TextVault/vigenere.py
@@ -9,9 +9,10 @@ class VigenereEncryptor(Encryptor):
         
         key_length = 10  # Set the length of the key
         key = ''.join(random.choice(string.ascii_uppercase) for _ in range(key_length))
-        pub = Key(value=key, encryptor=self)
-        priv = Key(value=key, encryptor=self)  # For Vigenère, both keys are the same
-        return pub, priv
+        
+        # Vigenère uses symmetric key
+        ret = Key(value=key)
+        return ret
 
     def encrypt(self, text: str, key: Key) -> str:
         
@@ -52,11 +53,11 @@ class VigenereEncryptor(Encryptor):
 """
 enc = VigenereEncryptor()
 
-pub,priv = enc.newkey()
-a = enc.encrypt("Hello, World!", pub)
+key = enc.newkey()
+a = enc.encrypt("Hello, World!", key)
 
 print(a)
-A= enc.decrypt(a, priv)
+A= enc.decrypt(a, key)
 print(A)
 
 """


### PR DESCRIPTION
상세

base_class의 Key에서 self.encryptor가 더 이상 사용되지 않도록 바뀐 것 반영

대칭 키 알고리즘에 대해서는 newkey()가 key tuple이 아니라 1개의 key를 리턴하게 하는 것 제안

close #17 